### PR TITLE
changed repo link in contribute and add event btn

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -14,12 +14,12 @@ const Footer: FC = () => {
       <p className="text-center">
         Thanks to all contributers to maintain this. 🙏 ❤️‍🔥 You can contribute at{' '}
         <a
-          href="https://github.com/mkubdev/DevConf"
+          href="https://github.com/WebXDAO/DevConf"
           className="udnerline text-primary"
           target={'_blank'}
           rel="noreferrer"
         >
-          github.com
+          WebXDAO/DevConf
         </a>
         .{' '}
       </p>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -9,7 +9,7 @@ const Navbar: FC = () => {
           {'<Dev.Conf/>'}
         </Link>
         <a
-          href="https://github.com/mkubdev/DevConf"
+          href="https://github.com/WebXDAO/DevConf"
           className="btn btn-primary"
           target={'_blank'}
           rel="noreferrer"

--- a/src/lib/context/ContextWrapper.tsx
+++ b/src/lib/context/ContextWrapper.tsx
@@ -44,14 +44,22 @@ const ContextWrapper: FC<{ children: ReactElement }> = ({ children }) => {
         >
           <Navbar />
           {children}
-          <div className="sticky top-[100vh] w-full bg-base-100">
+          <div className="relative w-full bg-base-100">
             <div className="container relative mx-auto flex max-w-6xl flex-col gap-14 py-10">
               <div className="flex flex-col gap-5 px-2">
                 <Heading title="Add your Event" />
 
                 <div className="card max-w-max text-2xl font-medium">
                   <p>
-                    1. Fork the repo github.com
+                    1. Fork the repo{' '}
+                    <a
+                      href="https://github.com/WebXDAO/DevConf"
+                      className="udnerline text-primary"
+                      target={'_blank'}
+                      rel="noreferrer"
+                    >
+                      WebXDAO/DevConf
+                    </a>
                     <br /> 2. Add Event data in markdown file
                     <br /> 3. Create pull request and Your event will be live.
                     <br /> 4. That’s it. Just that.


### PR DESCRIPTION
## Related Issue

On navbar `add event` button and contribute link in footer was redirecting to `mkubdev/DevConf` 
changed to `WebXDAO/DevConf`.

## Type of change

What sort of change have you made:
 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## Checklist
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
