### PR TITLE
feat: add event date and time to card

### DIFF
--- a/src/components/Event/index.tsx
+++ b/src/components/Event/index.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const Event: FC<Props> = ({
-  event: { date, description, link, socials, themes, time, title },
+  event: { date, description, link, socials, themes, time, startTime, title },
 }) => {
   const socialIcons = useSocialIcons();
   return (
@@ -34,6 +34,7 @@ const Event: FC<Props> = ({
         {description}
       </span>
       <div className="mt-2 flex items-center justify-between">
+        {new Date(startTime).toUTCString()}
         <div>
           <span className="font-medium">Theme</span>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface EventInterface {
   title: string;
   description: string;
   date: string;
+  startTime: string;
   time: string;
   link: string;
   socials: Array<{ name: SocialIconsNameType; link: string }>;


### PR DESCRIPTION
I updated the typedef for the event card component to include the startTime. In the event card component I passed the startTime as a prop and applied it just above the theme to render the date & time of the event. Changes were made to the types file and Event file.