### PR TITLE
Feat : Add workflow to assign PR to the author

### DIFF
--- a/.github/workflows/author-assign-pr.yml
+++ b/.github/workflows/author-assign-pr.yml
@@ -1,0 +1,16 @@
+name: 'Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Related Issue

Closes: #271 

### Describe the changes you've made

- The purpose of this workflow is to automatically assign the author of the pull request. It uses the provided GitHub token
(secrets.GITHUB_TOKEN) to perform this action.

- By using this workflow, the author of a pull request will be automatically assigned when the pull request is opened or reopened in the repository.

## Type of change

What sort of change have you made:


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?

- I created a dummy repo and tested it there and it's working fine by assigning PR automatically to authors whenever a PR is opened or reopened.


## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.


## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/UniKonf/vibey/blob/main/CODE_OF_CONDUCT.md)
