### PR TITLE
fix: margin issue on privacy page and social icon hover

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -97,7 +97,7 @@ const Footer: FC = () => {
               <li className="md:mt-[-3.5rem]">
                 <Link
                   href="https://github.com/UniKonf/vibey"
-                  className="p-3 text-center text-3xl hover:text-gray-200"
+                  className="p-3 text-center text-3xl hover:text-blue-400"
                   target="_blank"
                   aria-label="Visit us on GitHub"
                 >

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,6 +1,6 @@
 export default function PrivacyPolicy() {
   return (
-    <article className="mx-auto pt-28 prose dark:prose-invert">
+    <article className="mx-5 sm:mx-auto pt-28 prose dark:prose-invert">
       <h1>Privacy Policy for Vibey</h1>
 
       <p>


### PR DESCRIPTION
## Related Issue

- Information about the related issue

Closes: #509

### Describe the changes you've made

I have changed the tailwind classes.
Before PrivacyPolicy page only had a vertical margin auto
Now for mobile devices, it has a vertical margin of 1.25rem or 20px, and for others auto

GitHub social icon hover color change.

## Type of change

What sort of change have you made:
I have changed and updated the tailwind class for article tag
Before: mx-auto
After: mx-5 sm:mx-auto

GitHub Social Icon:
Before: hover:text-gray-200
After: hover:text-blue-400

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Describe how have you verified the changes made -->
I have run the code on my local machine

## Checklist

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| ![image](https://github.com/UniKonf/vibey/assets/120767897/1b5cd809-dbab-4c5d-adf9-5dde3d18d448) | ![image](https://github.com/UniKonf/vibey/assets/120767897/2fed59dc-2fd6-4881-9891-c0319ca1bc8e) |

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| ![image](https://github.com/UniKonf/vibey/assets/120767897/eba42c40-0ea2-482d-bb97-8a3acafdd4a2) | ![image](https://github.com/UniKonf/vibey/assets/120767897/dfe80966-287e-48fc-94ab-ccdbe86a80b8) |

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/UniKonf/vibey/blob/main/CODE_OF_CONDUCT.md)
